### PR TITLE
Corrigido ordenação de nós usando BTreeMap e u8 como chave

### DIFF
--- a/src/application/executor.rs
+++ b/src/application/executor.rs
@@ -4,12 +4,12 @@ use crate::infrastructure::repositories::Workflow;
 
 #[derive(Default)]
 pub struct ExecutionContext {
-    pub memory: HashMap<String, serde_json::Value>,
+    pub memory: HashMap<u16, serde_json::Value>,
 }
 
 pub fn run_workflow(workflow: &Workflow) {
     let mut queue = VecDeque::new();
-    queue.push_back("1".to_string());
+    queue.push_back(1);
     let mut context = ExecutionContext::default();
 
     while let Some(current_id) = queue.pop_front() {
@@ -22,7 +22,7 @@ pub fn run_workflow(workflow: &Workflow) {
     println!("✅ Fluxo finalizado. Contexto: {:?}", context.memory);
 }
 
-fn execute_node(node: &Node, ctx: &mut ExecutionContext, queue: &mut VecDeque<String>) {
+fn execute_node(node: &Node, ctx: &mut ExecutionContext, queue: &mut VecDeque<u16>) {
     println!("🔹 Executando '{}'", node.name);
 
 
@@ -32,7 +32,7 @@ fn execute_node(node: &Node, ctx: &mut ExecutionContext, queue: &mut VecDeque<St
             println!("   ➥ Manual Trigger");
 
             for next_node in node.next.as_ref().unwrap().iter() {
-                queue.push_back(next_node.clone());
+                queue.push_back(*next_node);
             }
         }
         NodeKind::WebhookV1(webhook_node) => {
@@ -42,7 +42,7 @@ fn execute_node(node: &Node, ctx: &mut ExecutionContext, queue: &mut VecDeque<St
             println!("   ➥ Set vars: {:?}", set_node.data);
 
             for next_node in node.next.as_ref().unwrap().iter() {
-                queue.push_back(next_node.clone());
+                queue.push_back(*next_node);
             }
         }
         NodeKind::IfV1(node) => {

--- a/src/domain/entities/node.rs
+++ b/src/domain/entities/node.rs
@@ -10,7 +10,7 @@ pub struct Node {
     #[serde(default)]
     pub conditions: Option<EdgeCondition>,
     #[serde(default)]
-    pub next: Option<Vec<String>>,
+    pub next: Option<Vec<u16>>,
 }
 
 impl Node {

--- a/src/infrastructure/repositories/workflow.rs
+++ b/src/infrastructure/repositories/workflow.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 use crate::domain::entities::Node;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct Workflow {
@@ -9,5 +9,46 @@ pub struct Workflow {
     pub pub_id: String,
     pub name: Option<String>,
     pub description: Option<String>,
-    pub nodes: HashMap<String, Node>,
+    #[serde(deserialize_with = "deserialize_u16_keyed_map")]
+    pub nodes: BTreeMap<u16, Node>,
+}
+
+use serde::de::{Deserializer, MapAccess, Visitor};
+use std::fmt;
+
+fn deserialize_u16_keyed_map<'de, D, V>(deserializer: D) -> Result<BTreeMap<u16, V>, D::Error>
+where
+    D: Deserializer<'de>,
+    V: Deserialize<'de>,
+{
+    struct StringKeyMapVisitor<V> {
+        marker: std::marker::PhantomData<fn() -> BTreeMap<u16, V>>,
+    }
+
+    impl<'de, V> Visitor<'de> for StringKeyMapVisitor<V>
+    where
+        V: Deserialize<'de>,
+    {
+        type Value = BTreeMap<u16, V>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a map with u16 keys represented as strings")
+        }
+
+        fn visit_map<M>(self, mut access: M) -> Result<Self::Value, M::Error>
+        where
+            M: MapAccess<'de>,
+        {
+            let mut map = BTreeMap::new();
+            while let Some((key, value)) = access.next_entry::<String, V>()? {
+                let parsed_key = key.parse::<u16>().map_err(serde::de::Error::custom)?;
+                map.insert(parsed_key, value);
+            }
+            Ok(map)
+        }
+    }
+
+    deserializer.deserialize_map(StringKeyMapVisitor {
+        marker: std::marker::PhantomData,
+    })
 }


### PR DESCRIPTION
# Correções
- A cadeia de nós não estava respeitando a ordem especificada no json do payload, para forçar esse comportamento foi necessário alterar de `HashMap` para `BTreeMap`.
- Para obter uma garantia de ordenação lexica, foi necessário alterar a chave da collection de `&str` para `u16`.